### PR TITLE
Hide .bundle folders

### DIFF
--- a/files_to_copy/.gitignore
+++ b/files_to_copy/.gitignore
@@ -39,3 +39,4 @@ Gemfile.lock
 spec/fixtures/*.itmsp/*.png
 /integration
 **/report.xml
+**/.bundle


### PR DESCRIPTION
Related to the newly introduced `bundle install --jobs=4 --retry=3` command